### PR TITLE
Add function argument for run()

### DIFF
--- a/threading_fun.py
+++ b/threading_fun.py
@@ -31,11 +31,22 @@ class my_thread(threading.Thread):
 
     def stopped(self):
         return self._stop_event.is_set()
-    def run(self):
-        """ Method that runs forever """
+    def run(self, funct, args):
+        """ 
+        Method that runs forever
+
+        ## Arguments
+        + funct : A function object to be called
+        + args : List of arguments
+        
+        ## Usage
+        run(print_Hello, ['hello', 'world'])
+        will attempt to call print_hello('hello', 'world')
+        """
         while not self.stopped():
             # Do something
-            print('Doing something imporant in the background')
+            funct(args[0], args[1])
+            #print('Doing something imporant in the background')
 
     def return_packets(): # this function is to retrive the packets outside the thread
         return my_thread.pkts


### PR DESCRIPTION
Now a function can be passed as an argument for thread.run()
the second argument should be a list of arguments of any type

Example

```python
def my_print(word1, word2):
  print("hello world, from", word1, word2)

x.run(my_print, ['networks', 'cse'])
# this should call the function my_print from the thread and pass the 1st two arguments
# in the list to it
```